### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Capture the Flag for Informatics 310: Information Assurance and Cyber Security at the University of Washington
 
-##Setup
+## Setup
 + Install Python 3.7 or greater
-+ Update pip `python -m pip install --upgrade pip`
-+ Install tkinter if not already installed `python -m pip install --upgrade pip`
++ Update pip `python3 -m pip install --upgrade pip`(if this errors, do `python -m pip install --upgrade pip`)
++ Install tkinter if not already installed `pip3 install tkinter`(if this errors do `pip install tkinter`)
 + Open client and server settings.config and adjust based on needs
 + Run Server (python3 ./server/server.py) and Client (python3 ./client/start.py)
 
@@ -23,7 +23,7 @@
 3. Find special code
 4. Enter into flag
 
-##Notes
+## Notes
 * Technically a user could modify source code to get credentials without monitoring the network.
 
 Copyright © Eric Cohen 2021


### PR DESCRIPTION
fixed your markdown syntax for instructions as well as added the correct commands for installing tkinter and upgrading pip.

the `python3` and `pip3` is for if they are on linux and are using the proper version of python, provided contingency but be aware it might error.

i would recommend doing a requirements.txt and allowing them to do `pip3 install -r requirements.txt`